### PR TITLE
Fix scheduled scan log "FOUND" detection

### DIFF
--- a/src/schedulescanobject.cpp
+++ b/src/schedulescanobject.cpp
@@ -344,7 +344,7 @@ void scheduleScanObject::slot_infectedFilesButtonClicked()
 {
     QTextCursor cursor = m_ui.logMessagePlainTextEdit->textCursor();
     QString searchString = "FOUND";
-    int pos = m_ui.logMessagePlainTextEdit->toPlainText().toUpper().indexOf(searchString, m_infectedStart);
+    int pos = m_ui.logMessagePlainTextEdit->toPlainText().indexOf(searchString, m_infectedStart);
 
     if (pos >= 0) {
         m_infectedStart = pos + searchString.length();
@@ -353,7 +353,7 @@ void scheduleScanObject::slot_infectedFilesButtonClicked()
         cursor.movePosition(QTextCursor::Right, QTextCursor::KeepAnchor, searchString.length());
         m_ui.logMessagePlainTextEdit->setTextCursor(cursor);
         m_ui.logMessagePlainTextEdit->ensureCursorVisible();
-        if (m_ui.logMessagePlainTextEdit->toPlainText().toUpper().indexOf(searchString, m_infectedStart) == -1) {
+        if (m_ui.logMessagePlainTextEdit->toPlainText().indexOf(searchString, m_infectedStart) == -1) {
             m_infectedStart = 0;
         }
     }


### PR DESCRIPTION
It was finding lowercase "found" texts from parts of directories (that should still happen if the dir has capital FOUND in it)