### PR TITLE
Fix log load leak

### DIFF
--- a/src/logviewerobject.cpp
+++ b/src/logviewerobject.cpp
@@ -5,6 +5,7 @@ logViewerObject::logViewerObject(QWidget* parent, setupFileHandler* setupFile) :
 {
     //m_setupfile = new setupFileHandler(QDir::homePath() + "/.clamav-gui/settings.ini", this); --> uses the setupFileHandler provided by the clamav_gui class
     m_ui->setupUi(this);
+    m_logObjectsList = QList<partialLogObject*>();
     slot_profilesChanged();
 }
 
@@ -56,6 +57,12 @@ void logViewerObject::loadLogFile(QString profile)
         m_ui->logTab->removeTab(0);
     }
 
+    for(int i = 0; i < m_logObjectsList.count(); i++) {
+        delete m_logObjectsList[i];
+    }
+
+    m_logObjectsList.clear();
+
     values = sf->getSectionValue("Directories", "ScanReportToFile").split("|");
     if (values.count() == 2) {
         QFile file(values[1]);
@@ -66,6 +73,7 @@ void logViewerObject::loadLogFile(QString profile)
             logs = buffer.split("<Scanning startet>");
             for (int i = 1; i < logs.count(); i++) {
                 partialLogObject* log = new partialLogObject(this, logs[i], css);
+                m_logObjectsList.append(log);
                 connect(this, SIGNAL(logHighlightingChanged(bool)), log, SLOT(slot_add_remove_highlighter(bool)));
                 tabHeader = logs[i].mid(1, logs[i].indexOf("\n") - 1);
                 m_ui->logTab->insertTab(0, log, QIcon(":/icons/icons/information.png"), tabHeader);
@@ -75,6 +83,8 @@ void logViewerObject::loadLogFile(QString profile)
             file.close();
         }
     }
+
+    delete sf;
 }
 
 void logViewerObject::slot_profileSeclectionChanged()

--- a/src/logviewerobject.h
+++ b/src/logviewerobject.h
@@ -24,6 +24,7 @@
 #include <QWidget>
 #include <QFile>
 #include <QDir>
+#include <QList>
 #include "setupfilehandler.h"
 #include "partiallogobject.h"
 
@@ -43,6 +44,7 @@ private:
     Ui::logViewerObject *m_ui;
     setupFileHandler    *m_setupfile;
     QString m_logFileName;
+    QList<partialLogObject*> m_logObjectsList;
     void loadLogFile(QString);
     void saveLog();
 

--- a/src/setupfilehandler.cpp
+++ b/src/setupfilehandler.cpp
@@ -61,6 +61,8 @@ void setupFileHandler::setSetupFileName(QString filename)
             file.close();
             file.flush();
         }
+
+        delete tempDir;
     }
 }
 


### PR DESCRIPTION
It seems that whenever log files were loaded, the old ones weren't being unloaded. For example, when we switch profiles in the logs tab, the "load logs" process runs again, but the memory was appearing to grow every time. I added a list to store the references for the log entries created during the load, so that, on the next load, we can delete them before creating new ones.

I'm not sure if the deletes for sf and tempDir that I added are really necessary, but it didn't crash haha