### PR TITLE
Use profile name as part of report file for new profiles

### DIFF
--- a/src/profilewizarddialog.cpp
+++ b/src/profilewizarddialog.cpp
@@ -112,6 +112,12 @@ void ProfileWizardDialog::readSettings()
     value = value.mid(value.indexOf("|") + 1);
     checked == "checked" ? m_ui->scanReportToFileCheckBox->setChecked(true) : m_ui->scanReportToFileCheckBox->setChecked(false);
     m_ui->scanReportToFileLineEdit->setText(value);
+    // use profile name as part of the report file for new profiles
+    if(m_newProfile){
+        QStringList pathSlices = value.split("/");
+        value = value.replace(pathSlices[pathSlices.length() - 1], m_profileName + "_scanreport.log");
+        m_ui->scanReportToFileLineEdit->setText(value);
+    }
 
     value = m_setupFile->getSectionValue("Directories", "ScanFilesFromFile");
     checked = value.left(value.indexOf("|"));


### PR DESCRIPTION
This helps separating log files for the logs tab (if all profiles use the same report file, it won't matter which profile we select in the logs tab, all reports of all profiles will be shown)