### PR TITLE
Also consider cld extension for main db check

### DIFF
--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -653,8 +653,13 @@ void optionsDialog::writeDirectories()
         if (m_ui.loadVirusDatabaseLineEdit->text() != "")
         {
             emit databasePathChanged(m_ui.loadVirusDatabaseLineEdit->text());
-            QFile file(m_ui.loadVirusDatabaseLineEdit->text() + "/main.cvd");
-            if ((file.exists() == false) && (m_setupFile->getSectionBoolValue("Setup","FirstRun") == false))
+            QFile* file = new QFile(m_ui.loadVirusDatabaseLineEdit->text() + "/main.cvd");
+            if(file->exists() == false)
+            {
+                delete file;
+                file = new QFile(m_ui.loadVirusDatabaseLineEdit->text() + "/main.cld");
+            }
+            if ((file->exists() == false) && (m_setupFile->getSectionBoolValue("Setup","FirstRun") == false))
             {
                 if (QMessageBox::warning(this, tr("Database files missing!"),
                                          tr("The virus definition files are missing in the database directory. Start download of the missing files?"),
@@ -663,6 +668,7 @@ void optionsDialog::writeDirectories()
                     emit updateDatabase();
                 }
             }
+            delete file;
         }
     }
     else {


### PR DESCRIPTION
My main database has the .cld extension, which was causing the GUI to think it was missing every time it was started